### PR TITLE
Fix tray restore action

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -112,7 +112,8 @@ class MainWindow(QMainWindow):
         self.tray = QSystemTrayIcon(QIcon(), self)
         tray_menu = QMenu()
         act_restore = QAction('显示窗口', self)
-        act_restore.triggered.connect(self.show_normal)
+        # Restore the main window when the tray icon action is triggered
+        act_restore.triggered.connect(self.showNormal)
         tray_menu.addAction(act_restore)
         act_shot = QAction('快速截图', self)
         act_shot.triggered.connect(self.take_shot)


### PR DESCRIPTION
## Summary
- connect system tray restore action to the correct `showNormal` method

## Testing
- `python -m py_compile src/main.py`
- `python src/main.py` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6849133c3d5083238c465de76d564a92