### PR TITLE
Fix missing import for QHBoxLayout

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QVBoxLayout, QWidget,
+    QApplication, QMainWindow, QVBoxLayout, QHBoxLayout, QWidget,
     QPushButton, QFileDialog, QMessageBox, QDialog, QFormLayout,
     QSpinBox, QComboBox, QLineEdit, QLabel, QSystemTrayIcon, QMenu,
     QCheckBox


### PR DESCRIPTION
## Summary
- fix missing QHBoxLayout import

## Testing
- `python3 -m py_compile $(find src -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849187049688323907d88518b86ce3d