### PR TITLE
Fix runtime type hint errors for Python <3.10

### DIFF
--- a/src/editor.py
+++ b/src/editor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QLabel, QPushButton, QHBoxLayout,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 import time
 import imageio.v2 as imageio


### PR DESCRIPTION
## Summary
- prevent evaluation of `|` type hints by enabling postponed evaluation

## Testing
- `python3 -m py_compile src/*.py`
- `python3 src/main.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68491d67b25c8323a4c1338344ae2cb4