### PR TITLE
Fix optional type hints for older Python versions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from settings import Settings
 from recorder import RecorderThread
+from typing import Optional
 from utils import take_screenshot, timestamp_filename, video_to_gif, select_region
 from editor import ScreenshotEditor
 
@@ -68,7 +69,7 @@ class MainWindow(tk.Tk):
         tk.Button(self, text="截图", command=self.take_shot).pack(side="left", padx=5)
         tk.Button(self, text="设置", command=self.open_settings).pack(side="left", padx=5)
         tk.Button(self, text="退出", command=self.exit_app).pack(side="left", padx=5)
-        self.thread: RecorderThread | None = None
+        self.thread: Optional[RecorderThread] = None
         if self.settings.start_minimized:
             self.withdraw()
 

--- a/src/recorder.py
+++ b/src/recorder.py
@@ -5,12 +5,13 @@ import threading
 from pathlib import Path
 
 from utils import Rect
+from typing import Optional
 
 
 class RecorderThread(threading.Thread):
     """Simple ffmpeg based screen recorder running in a thread."""
 
-    def __init__(self, output: Path, fps: int = 30, region: Rect | None = None,
+    def __init__(self, output: Path, fps: int = 30, region: Optional[Rect] = None,
                  on_finished=None, on_error=None):
         super().__init__(daemon=True)
         self.output = output

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import time
 import tkinter as tk
+from typing import Optional, Tuple
 from PIL import Image
 import imageio.v2 as imageio
 import mss
@@ -29,9 +30,9 @@ class RegionSelector(tk.Toplevel):
         self.configure(background="black")
         self.canvas = tk.Canvas(self, cursor="cross", highlightthickness=0, bg="black")
         self.canvas.pack(fill=tk.BOTH, expand=True)
-        self.start_pos: tuple[int, int] | None = None
-        self.rect_id: int | None = None
-        self.selected: Rect | None = None
+        self.start_pos: Optional[Tuple[int, int]] = None
+        self.rect_id: Optional[int] = None
+        self.selected: Optional[Rect] = None
         self.bind("<ButtonPress-1>", self.on_press)
         self.bind("<B1-Motion>", self.on_drag)
         self.bind("<ButtonRelease-1>", self.on_release)
@@ -68,7 +69,7 @@ class RegionSelector(tk.Toplevel):
         self.destroy()
 
 
-def select_region(master=None) -> Rect | None:
+def select_region(master=None) -> Optional[Rect]:
     root = tk.Tk() if master is None else master
     if master is None:
         root.withdraw()
@@ -80,7 +81,7 @@ def select_region(master=None) -> Rect | None:
     return selector.selected
 
 
-def take_screenshot(path: Path, region: Rect | None = None) -> Path:
+def take_screenshot(path: Path, region: Optional[Rect] = None) -> Path:
     """Capture a screenshot optionally limited to *region*."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with mss.mss() as sct:


### PR DESCRIPTION
## Summary
- use `Optional` and `Tuple` for backwards compatible type hints
- make recorder and utils imports include `typing`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68498c9c7eac8323ad197ea0b0288760