### PR TITLE
Fix DPI-aware coordinates

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,17 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from pathlib import Path
 import time
+import sys
+
+if sys.platform.startswith("win"):
+    try:
+        from ctypes import windll
+        try:
+            windll.shcore.SetProcessDpiAwareness(2)
+        except Exception:
+            windll.user32.SetProcessDPIAware()
+    except Exception:
+        pass
 
 from settings import Settings
 from recorder import RecorderThread


### PR DESCRIPTION
## Summary
- ensure process DPI awareness on Windows to avoid incorrect mouse coordinates in the region selector

## Testing
- `python -m py_compile src/main.py src/utils.py src/recorder.py src/editor.py src/settings.py KeyleFinderModule.py`


------
https://chatgpt.com/codex/tasks/task_e_684991f657d48323a04655e006eeae47