### PR TITLE
Fix region selection scaling

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -23,7 +23,10 @@ class RegionSelector(tk.Toplevel):
 
     def __init__(self, master=None):
         super().__init__(master)
-        self.scaling = float(self.tk.call("tk", "scaling"))
+        # Use raw pixel coordinates. Multiplying by the Tk scaling factor
+        # produced incorrect offsets on high-DPI displays, so we keep the
+        # value at 1.0 to avoid extra scaling.
+        self.scaling = 1.0
         self.withdraw()
         self.overrideredirect(True)
         self.attributes("-fullscreen", True)


### PR DESCRIPTION
## Summary
- avoid applying Tk scaling to coordinates

## Testing
- `python -m py_compile src/recorder.py src/editor.py src/utils.py src/main.py src/settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849970b23748323a42d79a317f1d510